### PR TITLE
상품 조회수 top3 확인 기능 추가 및 각 상품의 일별 조회수 확인 기능 추가

### DIFF
--- a/src/main/java/com/heeha/domain/depositsProduct/controller/DepositsProductController.java
+++ b/src/main/java/com/heeha/domain/depositsProduct/controller/DepositsProductController.java
@@ -3,6 +3,7 @@ package com.heeha.domain.depositsProduct.controller;
 
 import com.heeha.domain.depositsProduct.dto.GetListDepositsProductResponse;
 import com.heeha.domain.depositsProduct.dto.GetDetailDepositsProductResponse;
+import com.heeha.domain.depositsProduct.dto.PreferenceInfo;
 import com.heeha.domain.depositsProduct.service.DepositsProductService;
 import com.heeha.global.config.BaseResponse;
 import io.swagger.v3.oas.annotations.Operation;
@@ -12,6 +13,7 @@ import io.swagger.v3.oas.annotations.media.Content;
 import io.swagger.v3.oas.annotations.media.Schema;
 import io.swagger.v3.oas.annotations.responses.ApiResponse;
 import io.swagger.v3.oas.annotations.responses.ApiResponses;
+import java.util.Map;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
 import org.springframework.web.bind.annotation.*;
@@ -65,6 +67,18 @@ public class DepositsProductController {
         depositsProductService.saveSavingProduct();
         depositsProductService.saveDepositProduct();
         return BaseResponse.success(true);
+    }
+
+    @GetMapping("/preference")
+    @Operation(summary = "상품 조회 순위 조회")
+    public BaseResponse.SuccessResult<Map<Integer, PreferenceInfo>> getPreferences() {
+        return BaseResponse.success(depositsProductService.getTopProduct());
+    }
+
+    @GetMapping("/preference/perday")
+    @Operation(summary = "특정 상품의 일별 조회수")
+    public BaseResponse.SuccessResult<Map<String,Integer>> getPerDayPreferences(@RequestParam(name = "productName") String productName) {
+        return BaseResponse.success(depositsProductService.getViewCountPerDay(productName));
     }
 }
 

--- a/src/main/java/com/heeha/domain/depositsProduct/dto/PreferenceInfo.java
+++ b/src/main/java/com/heeha/domain/depositsProduct/dto/PreferenceInfo.java
@@ -1,0 +1,19 @@
+package com.heeha.domain.depositsProduct.dto;
+
+import lombok.AllArgsConstructor;
+import lombok.Getter;
+import lombok.ToString;
+import org.jetbrains.annotations.NotNull;
+
+@AllArgsConstructor
+@Getter
+@ToString
+public class PreferenceInfo implements Comparable<PreferenceInfo> {
+    private String productName;
+    private Integer viewCount;
+
+    @Override
+    public int compareTo(@NotNull PreferenceInfo o) {
+        return Integer.compare(o.viewCount, this.viewCount);
+    }
+}

--- a/src/main/java/com/heeha/domain/depositsProduct/service/DepositsProductService.java
+++ b/src/main/java/com/heeha/domain/depositsProduct/service/DepositsProductService.java
@@ -3,16 +3,25 @@ package com.heeha.domain.depositsProduct.service;
 import com.heeha.domain.depositsProduct.dto.DepositsProductResponse;
 import com.heeha.domain.depositsProduct.dto.GetDetailDepositsProductResponse;
 import com.heeha.domain.depositsProduct.dto.GetListDepositsProductResponse;
+import com.heeha.domain.depositsProduct.dto.PreferenceInfo;
 import com.heeha.domain.depositsProduct.entity.DepositsProduct;
 import com.heeha.domain.depositsProduct.repository.DepositsProductRepository;
 import com.heeha.domain.depositsProduct.util.DepositsProductUtil;
 import com.heeha.global.aop.Preference;
 import com.heeha.global.config.BaseException;
 import com.heeha.global.config.BaseResponseStatus;
+import jakarta.persistence.criteria.CriteriaBuilder.In;
+import java.time.LocalDate;
+import java.util.HashMap;
+import java.util.Locale;
+import java.util.Map;
+import java.util.Objects;
 import java.util.Optional;
+import java.util.PriorityQueue;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
 import org.springframework.dao.DataIntegrityViolationException;
+import org.springframework.data.redis.core.RedisTemplate;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
 
@@ -27,6 +36,7 @@ public class DepositsProductService {
 
     private final DepositsProductRepository depositsProductRepository;
     private final DepositsProductUtil depositsProductUtil;
+    private final RedisTemplate<String, Object> redisTemplate;
 
     @Transactional
     public void saveSavingProduct() {
@@ -49,7 +59,7 @@ public class DepositsProductService {
     @Preference
     public DepositsProduct getDetail(Long id) {
         Optional<DepositsProduct> depositsProductResponse = depositsProductRepository.findById(id);
-        if(depositsProductResponse.isEmpty()) {
+        if (depositsProductResponse.isEmpty()) {
             throw new BaseException(BaseResponseStatus.INVALID_DEPOSIT_PRODUCT_ID);
         }
 
@@ -59,7 +69,7 @@ public class DepositsProductService {
     @Transactional
     public List<GetListDepositsProductResponse> getList() {
         List<DepositsProduct> depositsProductList = depositsProductRepository.findAll();
-        if(depositsProductList.isEmpty()) {
+        if (depositsProductList.isEmpty()) {
             throw new BaseException(BaseResponseStatus.EMPTY_DEPOSITS_PRODUCT);
         }
         return depositsProductList
@@ -71,12 +81,43 @@ public class DepositsProductService {
     @Transactional
     public List<GetListDepositsProductResponse> searchList(String searchword) {
         List<DepositsProduct> depositsProductList = depositsProductRepository.findByserchwordLike(searchword);
-        if(depositsProductList.isEmpty()) {
+        if (depositsProductList.isEmpty()) {
             throw new BaseException(BaseResponseStatus.EMPTY_DEPOSITS_PRODUCT);
         }
         return depositsProductList
                 .stream()
                 .map(GetListDepositsProductResponse::fromEntity)
                 .collect(Collectors.toList());
+    }
+
+    public Map<Integer, PreferenceInfo> getTopProduct() {
+        Map<Integer, PreferenceInfo> topProduct = new HashMap<>();
+        LocalDate today = LocalDate.now();
+
+        PriorityQueue<PreferenceInfo> queue = new PriorityQueue<>();
+        depositsProductRepository.findAll().forEach(depositsProduct -> {
+            String productName = depositsProduct.getFinPrdtNm();
+            if (Boolean.TRUE.equals(redisTemplate.opsForHash().hasKey(productName, today.toString()))) {
+                queue.add(new PreferenceInfo(productName, Integer.parseInt(
+                        (String) Objects.requireNonNull(
+                                redisTemplate.opsForHash().get(productName, today.toString())))));
+            }
+        });
+
+        int cnt = 1;
+        while (!queue.isEmpty() && cnt <= 3) {
+            topProduct.put(cnt++, queue.poll());
+        }
+
+        return topProduct;
+    }
+
+    public Map<String, Integer> getViewCountPerDay(String productName) {
+        Map<String, Integer> viewCountPerDay = new HashMap<>();
+        Map<Object, Object> entries = redisTemplate.opsForHash().entries(productName);
+        for (Map.Entry<Object, Object> entry : entries.entrySet()) {
+            viewCountPerDay.put(entry.getKey().toString(), Integer.parseInt(entry.getValue().toString()));
+        }
+        return viewCountPerDay;
     }
 }

--- a/src/main/java/com/heeha/domain/depositsProduct/service/DepositsProductService.java
+++ b/src/main/java/com/heeha/domain/depositsProduct/service/DepositsProductService.java
@@ -6,6 +6,7 @@ import com.heeha.domain.depositsProduct.dto.GetListDepositsProductResponse;
 import com.heeha.domain.depositsProduct.entity.DepositsProduct;
 import com.heeha.domain.depositsProduct.repository.DepositsProductRepository;
 import com.heeha.domain.depositsProduct.util.DepositsProductUtil;
+import com.heeha.global.aop.Preference;
 import com.heeha.global.config.BaseException;
 import com.heeha.global.config.BaseResponseStatus;
 import java.util.Optional;
@@ -45,6 +46,7 @@ public class DepositsProductService {
                 .toList());
     }
 
+    @Preference
     public DepositsProduct getDetail(Long id) {
         Optional<DepositsProduct> depositsProductResponse = depositsProductRepository.findById(id);
         if(depositsProductResponse.isEmpty()) {

--- a/src/main/java/com/heeha/global/aop/Preference.java
+++ b/src/main/java/com/heeha/global/aop/Preference.java
@@ -1,0 +1,11 @@
+package com.heeha.global.aop;
+
+import java.lang.annotation.ElementType;
+import java.lang.annotation.Retention;
+import java.lang.annotation.RetentionPolicy;
+import java.lang.annotation.Target;
+
+@Target({ElementType.TYPE, ElementType.METHOD})
+@Retention(RetentionPolicy.RUNTIME)
+public @interface Preference {
+}

--- a/src/main/java/com/heeha/global/aop/PreferenceAop.java
+++ b/src/main/java/com/heeha/global/aop/PreferenceAop.java
@@ -1,0 +1,47 @@
+package com.heeha.global.aop;
+
+import com.heeha.domain.depositsProduct.entity.DepositsProduct;
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+import org.aspectj.lang.JoinPoint;
+import org.aspectj.lang.ProceedingJoinPoint;
+import org.aspectj.lang.annotation.After;
+import org.aspectj.lang.annotation.Around;
+import org.aspectj.lang.annotation.Aspect;
+
+import org.aspectj.lang.annotation.Before;
+import org.aspectj.lang.annotation.Pointcut;
+import org.springframework.data.redis.core.RedisTemplate;
+import org.springframework.stereotype.Component;
+
+@Aspect
+@Component
+@Slf4j
+@RequiredArgsConstructor
+public class PreferenceAop {
+
+    private final RedisTemplate<String, Object> redisTemplate;
+
+    @Pointcut("@annotation(com.heeha.global.aop.Preference)")
+    private void cut() {
+    }
+
+
+    @Around("cut()")
+    public Object around(ProceedingJoinPoint joinPoint) throws Throwable {
+        Long productId = (Long) joinPoint.getArgs()[0];
+        log.info("예적금 상품 아이디 : {} 가 조회되었습니다.", productId);
+        DepositsProduct selectedProduct = (DepositsProduct) joinPoint.proceed();
+        log.info("조회된 상품명 : {}", selectedProduct.getFinPrdtNm());
+        updatePreference(selectedProduct.getFinPrdtNm());
+        return selectedProduct;
+    }
+
+    private void updatePreference(String productName) {
+        if (!redisTemplate.opsForValue().setIfAbsent(productName, "1")) {
+            int preference = Integer.parseInt((String) redisTemplate.opsForValue().get(productName));
+
+            redisTemplate.opsForValue().set(productName, String.valueOf(preference + 1));
+        }
+    }
+}

--- a/src/main/java/com/heeha/global/config/RedisConfig.java
+++ b/src/main/java/com/heeha/global/config/RedisConfig.java
@@ -44,6 +44,8 @@ public class RedisConfig {
         redisTemplate.setConnectionFactory(redisConnectionFactory());
         redisTemplate.setKeySerializer(new StringRedisSerializer());
         redisTemplate.setValueSerializer(new StringRedisSerializer());
+        redisTemplate.setHashKeySerializer(new StringRedisSerializer());
+        redisTemplate.setHashValueSerializer(new StringRedisSerializer());
         return redisTemplate;
     }
 }


### PR DESCRIPTION
## 개요
Resolves: #29 

## PR 유형
상품의 조회수가 많은 순으로 Top 3 상품이름과 조회수를 반환하는 기능 추가
상품의 일별 조회수를 확인하는 기능 추가

- [ ] aop 타겟 메서드 애노테이션 추가 및 aop 설정 클래스 추가
- [ ] 상품 조회수 top3 반환 api 추가
- [ ] 일별 상품 조회수 반환하는 api 기능 추가

